### PR TITLE
Use moulinette dialog ID as scope for sound file selector to increase performance

### DIFF
--- a/moulinette-sounds.js
+++ b/moulinette-sounds.js
@@ -166,13 +166,13 @@ Hooks.on("preUpdatePlaylist", (playlist, updateData) => {
       let soundIdx = -1
       // find matching sound
       const filename = decodeURIComponent(sound.path.split("/").pop())
-      $(`.list .sound`).each(function( idx, snd ) {
+      $(`#moulinette .list .sound`).each(function( idx, snd ) {
         const fn = $(snd).attr("data-filename")
         if(fn && fn.endsWith(filename)) {
           soundIdx = $(snd).attr("data-idx")
         }
       })
-      $(`.list .sound[data-idx='${soundIdx}'] a[data-action='sound-play'] i`).attr("class", s.playing ? "fas fa-square" : "fas fa-play")
+      $(`#moulinette  .list .sound[data-idx='${soundIdx}'] a[data-action='sound-play'] i`).attr("class", s.playing ? "fas fa-square" : "fas fa-play")
     }
   }
 });
@@ -186,18 +186,18 @@ Hooks.on("preUpdatePlaylistSound", (playlistSound, updateData) => {
     let sound = -1
     // find matching sound
     const filename = decodeURIComponent(playlistSound.path.split("/").pop())
-    $(`.list .sound`).each(function( idx, snd ) {
+    $(`#moulinette .list .sound`).each(function( idx, snd ) {
       const fn = $(snd).attr("data-filename")
       if(fn && fn.endsWith(filename)) {
         sound = $(snd).attr("data-idx")
       }
     })
     if(Object.keys(updateData).includes("volume")) {
-      $(`.list .sound[data-idx='${sound}'] .sound-volume input`).val(AudioHelper.volumeToInput(updateData.volume))
+      $(`#moulinette .list .sound[data-idx='${sound}'] .sound-volume input`).val(AudioHelper.volumeToInput(updateData.volume))
     } else if(Object.keys(updateData).includes("repeat")) {
-      $(`.list .sound[data-idx='${sound}'] a[data-action='sound-repeat']`).attr("class", updateData.repeat ? "sound-control" : "sound-control inactive")
+      $(`#moulinette .list .sound[data-idx='${sound}'] a[data-action='sound-repeat']`).attr("class", updateData.repeat ? "sound-control" : "sound-control inactive")
     } else if(Object.keys(updateData).includes("playing")) {
-      $(`.list .sound[data-idx='${sound}'] a[data-action='sound-play'] i`).attr("class", updateData.playing ? "fas fa-square" : "fas fa-play")
+      $(`#moulinette .list .sound[data-idx='${sound}'] a[data-action='sound-play'] i`).attr("class", updateData.playing ? "fas fa-square" : "fas fa-play")
     }
   }
 });


### PR DESCRIPTION
This might seem like a small thing, but increases performance quite dramatically in a busy foundry environment.

Now, 'quite dramatically' is still reletive. It will not increase the fps in foundry or make character sheets buttery smooth all of a sudden, but it does greatly reduce UI lag whenever the sounds sidebar is updated, which is at least every time a track is started or completed.

For quite a few people, this will happen directly when combat begins or in other busy situations and in my world with only about 160 sounds distributed among many playlists, just running the `preUpdatePlaylist` moulinette hook takes about 100ms. 100ms itself might not seem bad, but when this is stacked on top of other inefficiencies in other modules, 3 modules each taking about 100ms extra can lead to a sudden, half-second freeze of the ui every now and then, which then is very noticable.

This simple change essentially reduces time this hook runs for me from about 100ms to 6ms.